### PR TITLE
Create collector visitor implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 sudo: false
 language: ruby
-env:
-  global:
-    COVERAGE=1
-    CC_TEST_REPORTER_ID=2ed4169686262bba86b94f45f05a5f9dcc00226feb75e3928563914a066512d6
 rvm:
   - 2.2
 

--- a/lib/pipe_flow.rb
+++ b/lib/pipe_flow.rb
@@ -13,5 +13,6 @@ require 'pipe_flow/parser/ast/pipe'
 
 require 'pipe_flow/parser/visitors/visitor'
 require 'pipe_flow/parser/visitors/validation'
+require 'pipe_flow/parser/visitors/collector'
 
 require 'pipe_flow/parser/context'

--- a/lib/pipe_flow/parser/visitors/collector.rb
+++ b/lib/pipe_flow/parser/visitors/collector.rb
@@ -1,0 +1,38 @@
+module PipeFlow
+  module Parser
+    module Visitors
+      class Collector < Visitors::Visitor
+        alias collect visit
+
+        def collected
+          @collected ||= []
+        end
+
+        # rubocop:disable Naming/MethodName
+        def visit_PipeFlow_Parser_AST_Hole(_hole)
+          collected << ->(x) { x }
+        end
+
+        def visit_PipeFlow_Parser_AST_Literal(literal)
+          value = literal.value
+          value = ->(_input) { value } unless value.is_a?(Proc)
+          collected << value
+        end
+
+        def visit_PipeFlow_Parser_AST_MethodCall(method_call)
+          receiver = method_call.env.eval('self')
+          method_name = method_call.method_id
+          args = method_call.arguments
+
+          collected << ->(x) { receiver.send(method_name, x, *args) }
+        end
+
+        def visit_PipeFlow_Parser_AST_Pipe(pipe)
+          visit(pipe.source)
+          visit(pipe.destination)
+        end
+        # rubocop:enable Naming/MethodName
+      end
+    end
+  end
+end

--- a/spec/pipe_flow/parser/visitors/collector_spec.rb
+++ b/spec/pipe_flow/parser/visitors/collector_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe PipeFlow::Parser::Visitors::Collector do
+  let(:instance) { described_class.new }
+
+  context '#visit' do
+    subject { instance.collect(input) }
+    let(:collected) { instance.collected }
+
+    context 'for a AST::Hole' do
+      let(:input) { PipeFlow::Parser::AST::Hole.instance }
+      before { subject }
+
+      it 'collects a single result' do
+        expect(collected.size).to eq(1)
+      end
+
+      it 'results in a proc' do
+        expect(collected.first).to be_a(Proc)
+      end
+    end
+
+    context 'for a AST::Literal' do
+      let(:input) { PipeFlow::Parser::AST::Literal.new(double('Literal Value')) }
+      before { subject }
+
+      it 'collects a single result' do
+        expect(collected.size).to eq(1)
+      end
+
+      it 'results in a proc' do
+        expect(collected.first).to be_a(Proc)
+      end
+    end
+
+    context 'for a AST::MethodCall' do
+      let(:fake_env) { object_double(binding) }
+      let(:fake_self) { double('Receiver') }
+
+      let(:input) { PipeFlow::Parser::AST::MethodCall.new(fake_env, :test_method, []) }
+
+      before do
+        allow(fake_env).to receive(:eval).with(anything).and_return([], fake_self)
+        subject
+      end
+
+      it 'collects a single result' do
+        expect(collected.size).to eq(1)
+      end
+
+      it 'results in a proc' do
+        expect(collected.first).to be_a(Proc)
+      end
+    end
+
+    context 'for a AST::Pipe' do
+      let(:input) { PipeFlow::Parser::AST::Pipe.new(source, destination) }
+      let(:source) { PipeFlow::Parser::AST::Hole.instance }
+      let(:destination) { PipeFlow::Parser::AST::Literal.new(double('Literal Value')) }
+
+      it 'collects two results' do
+        subject
+        expect(collected.size).to eq(2)
+      end
+
+      it 'visits the source and destination nodes as a pre-order traversal', aggregate_failures: true do
+        expect(instance).to receive(:visit).with(source).and_call_original.ordered
+        expect(instance).to receive(:visit).with(destination).and_call_original.ordered
+        subject
+      end
+
+      it 'results in only procs' do
+        subject
+        expect(collected).to all(be_a Proc)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This transforms the AST into an array of procs that can be composed in serial.

_This PR is mostly a happy path test for the travis-ci integration._